### PR TITLE
Fix deploy notebook for Azure Databricks compatibility

### DIFF
--- a/04_deploy_model.ipynb
+++ b/04_deploy_model.ipynb
@@ -133,7 +133,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "application/vnd.databricks.v1+cell": {
      "cellMetadata": {
@@ -148,41 +148,7 @@
     }
    },
    "outputs": [],
-   "source": [
-    "# Get the champion model version\n",
-    "champion_version = client.get_model_version_by_alias(model_name, \"champion\")\n",
-    "model_version = champion_version.version\n",
-    "\n",
-    "my_json = {\n",
-    "    \"name\": model_serving_endpoint_name,\n",
-    "    \"config\": {\n",
-    "        \"served_models\": [\n",
-    "            {\n",
-    "                \"model_name\": model_name,\n",
-    "                \"model_version\": model_version,\n",
-    "                \"workload_type\": \"GPU_MEDIUM\",\n",
-    "                \"workload_size\": \"Small\",\n",
-    "                \"scale_to_zero_enabled\": \"false\",\n",
-    "            }\n",
-    "        ],\n",
-    "        \"auto_capture_config\": {\n",
-    "            \"catalog_name\": catalog,\n",
-    "            \"schema_name\": log_schema,\n",
-    "            \"table_name_prefix\": model_serving_endpoint_name,\n",
-    "        },\n",
-    "    },\n",
-    "}\n",
-    "\n",
-    "# Make sure to the schema for the inference table exists\n",
-    "_ = spark.sql(\n",
-    "    f\"CREATE SCHEMA IF NOT EXISTS {catalog}.{log_schema}\"\n",
-    ")\n",
-    "\n",
-    "# Make sure to drop the inference table of it exists\n",
-    "_ = spark.sql(\n",
-    "    f\"DROP TABLE IF EXISTS {catalog}.{log_schema}.`{model_serving_endpoint_name}_payload`\"\n",
-    ")"
-   ]
+   "source": "# Get the champion model version\nchampion_version = client.get_model_version_by_alias(model_name, \"champion\")\nmodel_version = champion_version.version\n\nmy_json = {\n    \"name\": model_serving_endpoint_name,\n    \"config\": {\n        \"served_models\": [\n            {\n                \"model_name\": model_name,\n                \"model_version\": model_version,\n                \"workload_type\": \"GPU_LARGE\",\n                \"workload_size\": \"Small\",\n                \"scale_to_zero_enabled\": \"false\",\n            }\n        ],\n    },\n}"
   },
   {
    "cell_type": "markdown",
@@ -208,7 +174,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "application/vnd.databricks.v1+cell": {
      "cellMetadata": {
@@ -223,32 +189,7 @@
     }
    },
    "outputs": [],
-   "source": [
-    "import mlflow.deployments\n",
-    "\n",
-    "def func_create_endpoint(json):\n",
-    "    client = mlflow.deployments.get_deploy_client(\"databricks\")\n",
-    "    try:\n",
-    "        # Check if the endpoint already exists\n",
-    "        client.get_deployment(json[\"name\"])\n",
-    "        # Update the existing endpoint with the new model version\n",
-    "        client.update_deployment(\n",
-    "            name=json[\"name\"], \n",
-    "            config=json[\"config\"]\n",
-    "        )\n",
-    "    except:\n",
-    "        # Create a new endpoint if it doesn't exist\n",
-    "        client.create_endpoint(\n",
-    "            name = model_serving_endpoint_name,\n",
-    "            config = json[\"config\"],\n",
-    "        )\n",
-    "\n",
-    "def func_delete_model_serving_endpoint(json):\n",
-    "    client = mlflow.deployments.get_deploy_client(\"databricks\")\n",
-    "    # Delete the specified endpoint\n",
-    "    client.delete_endpoint(json[\"name\"])\n",
-    "    print(json[\"name\"], \"endpoint is deleted!\")"
-   ]
+   "source": "from databricks.sdk import WorkspaceClient\nfrom databricks.sdk.service.serving import EndpointCoreConfigInput, ServedModelInput\n\ndef func_create_endpoint(config):\n    w = WorkspaceClient()\n    served_model = config[\"config\"][\"served_models\"][0]\n    served_model_input = ServedModelInput.from_dict(served_model)\n    try:\n        w.serving_endpoints.create_and_wait(\n            name=config[\"name\"],\n            config=EndpointCoreConfigInput(served_models=[served_model_input]),\n        )\n        print(f\"Created endpoint: {config['name']}\")\n    except Exception as e:\n        if \"RESOURCE_ALREADY_EXISTS\" in str(e):\n            w.serving_endpoints.update_config_and_wait(\n                name=config[\"name\"],\n                served_models=[served_model_input],\n            )\n            print(f\"Updated existing endpoint: {config['name']}\")\n        else:\n            raise\n\ndef func_delete_model_serving_endpoint(config):\n    w = WorkspaceClient()\n    w.serving_endpoints.delete(name=config[\"name\"])\n    print(config[\"name\"], \"endpoint is deleted!\")"
   },
   {
    "cell_type": "code",
@@ -294,7 +235,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "application/vnd.databricks.v1+cell": {
      "cellMetadata": {
@@ -309,31 +250,7 @@
     }
    },
    "outputs": [],
-   "source": [
-    "def wait_for_endpoint(endpoint_name):\n",
-    "    '''Wait for a model serving endpoint to be ready'''\n",
-    "    from databricks.sdk import WorkspaceClient\n",
-    "    from databricks.sdk.service.serving import EndpointStateReady, EndpointStateConfigUpdate\n",
-    "    import time\n",
-    "\n",
-    "    # Initialize WorkspaceClient\n",
-    "    w = WorkspaceClient()\n",
-    "    state = \"\"\n",
-    "    for i in range(200):\n",
-    "        state = w.serving_endpoints.get(endpoint_name).state\n",
-    "        if state.config_update == EndpointStateConfigUpdate.IN_PROGRESS:\n",
-    "            if i % 40 == 0:\n",
-    "                print(f\"Waiting for endpoint to deploy {endpoint_name}. Current state: {state}\")\n",
-    "            time.sleep(10)\n",
-    "        elif state.ready == EndpointStateReady.READY:\n",
-    "            print('endpoint ready.')\n",
-    "            return\n",
-    "        else:\n",
-    "            break\n",
-    "    raise Exception(f\"Couldn't start the endpoint, timeout, please check your endpoint for more details: {state}\")\n",
-    "\n",
-    "wait_for_endpoint(my_json[\"name\"])"
-   ]
+   "source": "# Waiting is handled by create_and_wait / update_config_and_wait above\nprint(f\"Endpoint '{my_json['name']}' is ready.\")"
   },
   {
    "cell_type": "markdown",


### PR DESCRIPTION
## Summary
- **`GPU_MEDIUM` → `GPU_LARGE`**: `GPU_MEDIUM` with `Small` size is not supported on Azure Databricks. The notebook's own markdown already noted to use `GPU_LARGE` on Azure, but the code used `GPU_MEDIUM`.
- **Remove deprecated `auto_capture_config`**: Legacy inference tables are deprecated and can no longer be enabled. Removed the `auto_capture_config` block and associated schema/table creation SQL.
- **Replace `mlflow.deployments` with `databricks.sdk`**: The original `mlflow.deployments` client has issues — `update_deployment()` raises `NotImplementedError` and the error handling used a bare `except:` that silently swallowed errors. Replaced with `databricks.sdk.WorkspaceClient` using `create_and_wait()` / `update_config_and_wait()` which properly handles endpoint creation, updates, and waiting.
- **Simplify wait logic**: Removed the manual `wait_for_endpoint` polling loop since `create_and_wait` / `update_config_and_wait` handle this natively.

## Test plan
- [x] Tested end-to-end on Azure Databricks workspace (`adb-984752964297111.11.azuredatabricks.net`)
- [x] Notebooks 01-04 run successfully with `Standard_NC96ads_A100_v4` cluster, DBR 15.4 LTS ML GPU
- [x] Model serving endpoint `sdxl-fine-tuned-chair` created and serving images successfully
- [x] Verified endpoint responds to inference requests with 1024x1024 generated images

This pull request was AI-assisted by Isaac.